### PR TITLE
Update eshopworld.core package (#14)

### DIFF
--- a/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
+++ b/src/Eshopworld.Messaging/Eshopworld.Messaging.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     
-    <Version>1.2.0</Version>
-    <PackageReleaseNotes>Nuget Updates</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+    <PackageReleaseNotes>Updated to netstandard 2.1</PackageReleaseNotes>
 
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <DebugType>Portable</DebugType>
     <IncludeSource>True</IncludeSource>
@@ -24,13 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="eshopworld.core" Version="2.1.2" />
+    <PackageReference Include="eshopworld.core" Version="4.0.0" />
     <PackageReference Include="jetbrains.annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.24.1" />
     <PackageReference Include="microsoft.azure.servicebus" Version="3.4.0" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.2.0" />
     <PackageReference Include="polly" Version="7.1.0" />
-    <PackageReference Include="system.reactive" Version="4.1.6" />
+    <PackageReference Include="system.reactive" Version="4.3.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Eshopworld.Messaging.Tests/Eshopworld.Messaging.Tests.csproj
+++ b/src/Tests/Eshopworld.Messaging.Tests/Eshopworld.Messaging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>Full</DebugType>
 
     <IsPackable>false</IsPackable>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="eshopworld.core" Version="2.1.2" />
+    <PackageReference Include="eshopworld.core" Version="4.0.0" />
     <PackageReference Include="eshopworld.tests.core" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.4" />
     <PackageReference Include="microsoft.azure.management.fluent" Version="1.24.1" />
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="system.reactive" Version="4.1.6" />
+    <PackageReference Include="system.reactive" Version="4.3.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
* Update target frameworks

- Update messaging so that it targets .net standard 2.1 in order to mantain comptability with Eshopworld.Core.
- Update test project to netcoreapp 3.1 (required by above change for compatability)

* Update eshopworld.core

This commit updates eshopworld.core to version 4, it also updates the system.reactive to version 4.3.2 as it's required by eshopworld.core.

* Update package version and release notes