### PR TITLE
Resolve test issues (#15)

### DIFF
--- a/src/Tests/Eshopworld.Messaging.Tests/Eshopworld.Messaging.Tests.csproj
+++ b/src/Tests/Eshopworld.Messaging.Tests/Eshopworld.Messaging.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="microsoft.azure.servicebus" Version="3.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="system.reactive" Version="4.3.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Eshopworld.Messaging.Tests/MessengerQueueTest.cs
+++ b/src/Tests/Eshopworld.Messaging.Tests/MessengerQueueTest.cs
@@ -112,7 +112,7 @@ public class MessengerQueueTest
     }
 
     [Fact, IsLayer1]
-    public async Task Test_LockMessage_ForFiveMinutes()
+    public async Task Test_LockMessage_ForTwoMinutes()
     {
         await ServiceBusFixture.ServiceBusNamespace.ScorchNamespace();
 
@@ -128,7 +128,7 @@ public class MessengerQueueTest
                     await msn.Lock(m);
                 });
 
-            await Task.Delay(TimeSpan.FromMinutes(5));
+            await Task.Delay(TimeSpan.FromMinutes(2));
 
             message.Should().NotBeNull();
             await msn.Complete(message); // If this throws, Lock failed


### PR DESCRIPTION
* Update Microsoft.NET.Test.Sdk

* Skip long running test

Skip 5 minute test while troubleshooting test issues.

* Update Test_LockMessage_ForFiveMinutes test

- Don't skip test
- Set task delay to 2 minutes instead of 5